### PR TITLE
Adjacency list

### DIFF
--- a/src/service/routing/directions.clj
+++ b/src/service/routing/directions.clj
@@ -5,7 +5,7 @@
             [service.routing.graph.protocols :as rp]
             [service.routing.utils.math :as math]))
 
-(defn- length
+(defn length
   "A very simple value computation function for Arcs in a graph.
   Returns a SimpleValue with the length of the arc"
   [arc _]
@@ -53,6 +53,11 @@
 ;; but looking into the future it is good to make like this such that we
 ;; can always extend it with more parameters
 ;; https://www.mapbox.com/api-documentation/#retrieve-directions
+;; TODO: we still need to return the legs of a route
+;; see https://github.com/mapbox/mapbox-gl-directions/issues/133
+;; TODO: we need to handle special cases like
+;; - src/dst not found
+;; - shortest path not found (nil)
 (defn direction
   "given a graph and a sequence of keywordized parameters according to
    https://www.mapbox.com/api-documentation/#retrieve-directions

--- a/src/service/routing/graph/algorithms.clj
+++ b/src/service/routing/graph/algorithms.clj
@@ -15,9 +15,12 @@
    - :direction is one of ::forward or ::backward and determines whether
      to use the outgoing or incoming arcs of each node"
   [graph & {:keys [start-from direction value-by]}]
-  (let [arcs (condp = direction ::forward  rp/successors
-                                ::backward rp/predecessors)]
-    (route/->Dijkstra graph start-from value-by arcs)))
+  (let [direction (or direction ::forward)
+        arcs (case direction ::forward  rp/successors
+                             ::backward rp/predecessors)
+        f    (case direction ::forward rp/dst
+                             ::backward rp/src)]
+    (route/->Dijkstra graph start-from value-by arcs f)))
 
 (defn breath-first
   "returns a constant SimpleValue of 1"
@@ -88,31 +91,31 @@
 ;(biggest-component rosetta)
 
 ;; NOTE: for testing purposes only
-;(def rosetta {1 {:out-arcs {2 {:dst 2 :length 7  :kind :other}
-;                            3 {:dst 3 :length 9  :kind :other}
-;                            6 {:dst 6 :length 14 :kind :other}}
-;                 :in-arcs  {}}
-;              2 {:out-arcs {3 {:dst 3 :length 10 :kind :other}
-;                            4 {:dst 4 :length 15 :kind :other}}
-;                 :in-arcs  {1 {:src 1 :length 7  :kind :other}}}
-;              3 {:out-arcs {4 {:dst 4 :length 11 :kind :other}
-;                            6 {:dst 6 :length 2  :kind :other}}
-;                 :in-arcs  {1 {:src 1 :length 9  :kind :other}
-;                            2 {:src 2 :length 10 :kind :other}}}
-;              4 {:out-arcs {5 {:dst 5 :length 6  :kind :other}}
-;                 :in-arcs  {2 {:src 2 :length 15 :kind :other}
-;                            3 {:src 3 :length 11 :kind :other}}}
-;              5 {:out-arcs {6 {:dst 6 :length 9  :kind :other}}
-;                 :in-arcs  {4 {:src 4 :length 6  :kind :other}}}
-;              6 {:out-arcs {}
-;                 :in-arcs  {1 {:src 1 :length 14 :kind :other}
-;                            3 {:src 3 :length 2  :kind :other}
-;                            5 {:src 5 :length 9  :kind :other}}}})
+;(def rosetta {1 {:out-arcs [{:dst 2 :length 7  :kind :other}
+;                            {:dst 3 :length 9  :kind :other}
+;                            {:dst 6 :length 14 :kind :other}]
+;                 :in-arcs  nil}
+;              2 {:out-arcs [{:dst 3 :length 10 :kind :other}
+;                            {:dst 4 :length 15 :kind :other}]
+;                 :in-arcs  [{:src 1 :length 7  :kind :other}]}
+;              3 {:out-arcs [{:dst 4 :length 11 :kind :other}
+;                            {:dst 6 :length 2  :kind :other}]
+;                 :in-arcs  [{:src 1 :length 9  :kind :other}
+;                            {:src 2 :length 10 :kind :other}]}
+;              4 {:out-arcs [{:dst 5 :length 6  :kind :other}]
+;                 :in-arcs  [{:src 2 :length 15 :kind :other}
+;                            {:src 3 :length 11 :kind :other}]}
+;              5 {:out-arcs [{:dst 6 :length 9  :kind :other}]
+;                 :in-arcs  [{:src 4 :length 6  :kind :other}]}
+;              6 {:out-arcs nil
+;                 :in-arcs  [{:src 1 :length 14 :kind :other}
+;                            {:src 3 :length 2  :kind :other}
+;                            {:src 5 :length 9  :kind :other}]}})
 ;Distances from 1: ((1 0) (2 7) (3 9) (4 20) (5 26) (6 11))
 ;Shortest path: (1 3 4 5)
 
 ;(def performer (dijkstra rosetta
-;                         :value-by length
+;                         :value-by service.routing.directions/length
 ;                         :direction ::forward
 ;                         :start-from #{1}))
 ;(first performer)

--- a/src/service/routing/graph/core.clj
+++ b/src/service/routing/graph/core.clj
@@ -16,10 +16,15 @@
 (extend-type IPersistentMap
   rp/Context ;; allow Clojure's maps to behave in the same way that Node records
   (predecessors [this] (:in-arcs this))
-  (successors    [this] (:out-arcs this)))
+  (successors    [this] (:out-arcs this))
+  rp/Arc
+  (src [this] (:src this))
+  (dst [this] (:dst this)))
 
-;; FIXME: missing interface/protocol definition for arcs
-(defrecord Arc  [^long src ^long dst ^double length kind])
+(defrecord Arc  [^long src ^long dst ^double length kind]
+  rp/Arc
+  (src [_] src)
+  (dst [_] dst))
 
 ;; a simple representation of a worth function result where both cost and time
 ;; are the same
@@ -83,14 +88,14 @@
   to it
 
   utility function: DO NOT USE DIRECTLY."
-  [value node-arcs trace ^Queue queue]
-  (reduce-kv (fn [_ dst arc]
-                 (let [weight (rp/sum (value arc trace)
-                                      (val trace))]
-                   (.add queue (->IdentifiableTrace dst weight trace))
-                   queue))
-             queue
-             node-arcs))
+  [value f node-arcs trace ^Queue queue]
+  (reduce (fn [_ arc]
+            (let [weight (rp/sum (value arc trace)
+                                 (val trace))]
+              (.add queue (->IdentifiableTrace (f arc) weight trace))
+              queue))
+          queue
+          node-arcs))
 
 (defn- produce!
   "returns a lazy sequence of traces by sequentially mutating the
@@ -98,25 +103,24 @@
   the rest of them
 
   utility function: DO NOT USE DIRECTLY"
-  [graph value arcs ^Queue queue settled]
+  [graph value arcs f ^Queue queue settled]
   (let [trace (poll-unsettled! queue settled)]; (step! graph settled value arcs queue)
     (if (nil? trace) (list)
-      (let [next-queue   (relax-nodes! value (arcs (get graph (key trace))) trace queue)
+      (let [next-queue   (relax-nodes! value f (arcs (get graph (key trace))) trace queue)
             next-settled (conj! settled (key trace))]
         (cons trace
-              (lazy-seq (produce! graph value arcs next-queue next-settled)))))))
-
+              (lazy-seq (produce! graph value arcs f next-queue next-settled)))))))
 
 
 ; inspired by http://insideclojure.org/2015/01/18/reducible-generators/
 ; A Collection type which can reduce itself faster than first/next traversal over its lazy
 ; representation.
-(deftype Dijkstra [graph ids value arcs]
+(deftype Dijkstra [graph ids value arcs f]
   Seqable
   (seq [_]
     (let [queue   (init-queue ids)
           settled (transient (imap/int-set))]
-      (produce! graph value arcs queue settled)))
+      (produce! graph value arcs f queue settled)))
   ;; ------
   IReduceInit
   (reduce [_ rf init]
@@ -128,7 +132,7 @@
           (let [rr (rf ret trace)]
             (if (reduced? rr) @rr
               (recur rr
-                     (relax-nodes! value (arcs (get graph (key trace))) trace queue)
+                     (relax-nodes! value f (arcs (get graph (key trace))) trace queue)
                      (conj! settled (key trace)))))))))
   ;; ------
   IReduce
@@ -138,7 +142,7 @@
            settled (transient (imap/int-set))]
       (let [trace (poll-unsettled! queue settled)]
         (if (nil? trace) ret ;; empty queue
-          (let [next-queue   (relax-nodes! value (arcs (get graph (key trace))) trace queue)
+          (let [next-queue   (relax-nodes! value f (arcs (get graph (key trace))) trace queue)
                 next-settled (conj! settled (key trace))]
             (case (count settled)
               (0 1) (recur ret next-queue next-settled) ;; ignore ret and keep making items

--- a/src/service/routing/graph/protocols.clj
+++ b/src/service/routing/graph/protocols.clj
@@ -7,12 +7,13 @@
 ;; ------------------- design constrainst --------------------------------;
 ; we are only interested in graphs that can be represented as a mapping of
 ; int -> Node. Since this makes the mapping easier in Clojure while
-; keeping it immutable. We only allow a single arc per dst/src node a.k.a
-; simple graph, therefore we purposedly ignore multi-graph and pseudo-graphs
+; keeping it immutable. Although we focus on a single-arc-per src/dst model
+; we represent arcs as a list of edges, thus multiple arcs between the same
+; src and dst are possible for a single node.
 ; see http://mathworld.wolfram.com/Graph.html
 
-; We assume that all routings are time-dependent even if they are not, in which
-; case the user can simply ignore it. Furthermore we assume that all routings
+; We assume that routing are time-dependent even if they are not, in which
+; case the user can simply ignore it. Furthermore we assume that routing
 ; can be completely determined by a cost function regardless of how that cost
 ; is calculated.
 
@@ -51,4 +52,6 @@
   (time [this] "a number indicating how much time it takes to get to a specific node")
   (sum [this that] "adds two valuables into one"))
 
-;TODO: introduce protocols for edges
+(defprotocol Arc
+  (src [this] "the start node id of an Arc")
+  (dst [this] "the destination node id of an Arc"))

--- a/src/service/routing/osm.clj
+++ b/src/service/routing/osm.clj
@@ -47,16 +47,12 @@
         dst (get graph (:dst arc))
         ned (assoc arc :length (math/haversine (:lon src) (:lat src)
                                                (:lon dst) (:lat dst)))
-        nout (if (nil? (:out-arcs src))
-               (imap/int-map (:dst arc) ned)
-               (assoc (:out-arcs src) (:dst arc) ned))
-        nin  (if (nil? (:in-arcs dst))
-               (imap/int-map (:src arc) ned)
-               (assoc (:in-arcs dst) (:src arc) ned))]
+        nout (conj (:out-arcs src) ned)
+        nin  (conj (:in-arcs dst) ned)]
     (-> graph (assoc! (:src arc) (assoc src :out-arcs nout))
               (assoc! (:dst arc) (assoc dst :in-arcs nin)))))
 
-(defn ->element
+(defn- ->element
   "create a node or a sequence of arcs based on the OSM tag"
   [object]
   (case (:tag object)

--- a/test/service/routing/graph/generators.clj
+++ b/test/service/routing/graph/generators.clj
@@ -30,7 +30,7 @@
   (let [picker #(gen/elements (range (* 3 max)))
         arc     (s/gen :graph/arc {:arc/src picker
                                    :arc/dst picker})
-        arcs   #(gen/map (picker) arc {:min-elements 3 :max-elements 5})
+        arcs   #(gen/list-distinct arc {:min-elements 3 :max-elements 5})
         nodes   (s/gen :graph/node {:node/arcs arcs})]
     (gen/map (picker) nodes {:num-elements max, :max-tries 100})))
 

--- a/test/service/routing/graph/specs.clj
+++ b/test/service/routing/graph/specs.clj
@@ -1,7 +1,8 @@
 (ns service.routing.graph.specs
   (:require [clojure.set :as set]
             [clojure.spec.alpha :as s]
-            [service.routing.osm :as osm]))
+            [service.routing.osm :as osm]
+            [service.routing.graph.protocols :as rp]))
 
 (s/def :arc/kind (set (keys osm/speeds)))
 (s/def :arc/length (s/and int? pos?))
@@ -10,7 +11,7 @@
 
 (s/def :node/lat (s/and number? #(<= -90 % 90)))
 (s/def :node/lon (s/and number? #(<= -180 % 180)))
-(s/def :node/arcs (s/map-of int? :graph/arc))
+(s/def :node/arcs (s/coll-of :graph/arc :kind list?))
 (s/def :node/out-arcs :node/arcs)
 (s/def :node/in-arcs :node/arcs)
 
@@ -23,19 +24,9 @@
 (defn- valid-ids?
   "is every id used in the out/in arcs also a node id present in the graph?"
   [ids graph]
-  (let [outs (into #{} (comp (map :out-arcs) (map first)) (vals graph))
-        ins  (into #{} (comp (map :in-arcs) (map first)) (vals graph))]
+  (let [outs (into #{} (comp (map :out-arcs) (map rp/dst)) (vals graph))
+        ins  (into #{} (comp (map :in-arcs) (map rp/src)) (vals graph))]
     (empty? (set/difference ids (set/union outs ins)))))
-
-(defn- valid-out-arcs?
-  [graph]
-  (let [outs (map :out-arcs (vals graph))]
-    (every? (fn [[dst arc]] (= dst (:dst arc))) outs)))
-
-(defn- valid-in-arcs?
-  [graph]
-  (let [outs (map :in-arcs (vals graph))]
-    (every? (fn [[src arc]] (= src (:src arc))) outs)))
 
 ;; this could definitely be improved such that every node/arc
 ;; is checked individually but this will have to do for the moment)))
@@ -45,6 +36,4 @@
   [graph]
   (let [ids (set (keys graph))]
     (s/and :int-map/graph
-           (partial valid-ids? ids)
-           valid-out-arcs?
-           valid-in-arcs?)))
+           (partial valid-ids? ids))))


### PR DESCRIPTION
- refactored :out-arcs and :in-arcs to be lists instead of int-maps
- adapted algorithms accordingly
- make connected components algorithms lazy
- direction ::forward is now the default for Dijkstra